### PR TITLE
install-verible: Make github_token optional

### DIFF
--- a/install-verible/action.yml
+++ b/install-verible/action.yml
@@ -19,9 +19,15 @@ runs:
     - name: Download and unpack Verible
       shell: bash
       run: |
+          set -eo pipefail
           mkdir verible
+          if [[ ! -z "${{ inputs.github_token }}" ]]; then
+            _HEADER='authorization: Bearer ${{ inputs.github_token }}'
+          else
+            _HEADER=""
+          fi
           if [ "${{ inputs.verible_version }}" = "latest" ]; then
-            VERIBLE_RELEASES_JSON=$(curl --header 'authorization: Bearer ${{ inputs.github_token }}' -fsSL https://api.github.com/repos/chipsalliance/verible/releases/latest)
+            VERIBLE_RELEASES_JSON=$(curl --header "$_HEADER" -fsSL https://api.github.com/repos/chipsalliance/verible/releases/latest)
             VERIBLE_TARBALL=$(echo $VERIBLE_RELEASES_JSON | jq -r '.assets[] | select(.browser_download_url | test("(?=.*linux-static)(?=.*x86_64)")).browser_download_url')
           else
             VERIBLE_TARBALL="https://github.com/chipsalliance/verible/releases/download/${{ inputs.verible_version }}/verible-${{ inputs.verible_version }}-linux-static-x86_64.tar.gz"


### PR DESCRIPTION
Remove requirement for `github_token` from `verible-actions-common/install-verible`. The rationale behind this has been described in chipsalliance/verible-linter-action#33.

To reiterate: The `github_token` is not strictly necessary to access the GitHub API -- which is used to fetch the name of the release tarball.

I added a `set -eo pipefail` to fail fast if a command in the chain failed. This makes the error messages more relevant.

In theory, we could drop the `--header 'authorization: ...'` all together. I kept it for now.

For reference, I'm currently using this modified version (this exact branch) in [3j14/analog-in-fw/.github/workflows/lint.yml](https://github.com/3j14/analog-in-fw/blob/main/.github/workflows/lint.yml).