### PR TITLE
install-verible: Change syntax of curl header variable and if clauses

### DIFF
--- a/install-verible/action.yml
+++ b/install-verible/action.yml
@@ -21,12 +21,12 @@ runs:
       run: |
           set -eo pipefail
           mkdir verible
-          if [[ ! -z "${{ inputs.github_token }}" ]]; then
+          if [[ -n "${{ inputs.github_token }}" ]]; then
             _HEADER=(--header 'authorization: Bearer ${{ inputs.github_token }}')
           else
             _HEADER=()
           fi
-          if [ "${{ inputs.verible_version }}" = "latest" ]; then
+          if [[ "${{ inputs.verible_version }}" == "latest" ]]; then
             VERIBLE_RELEASES_JSON=$(curl "${_HEADER[@]}" -fsSL https://api.github.com/repos/chipsalliance/verible/releases/latest)
             VERIBLE_TARBALL=$(echo $VERIBLE_RELEASES_JSON | jq -r '.assets[] | select(.browser_download_url | test("(?=.*linux-static)(?=.*x86_64)")).browser_download_url')
           else

--- a/install-verible/action.yml
+++ b/install-verible/action.yml
@@ -22,12 +22,12 @@ runs:
           set -eo pipefail
           mkdir verible
           if [[ ! -z "${{ inputs.github_token }}" ]]; then
-            _HEADER='authorization: Bearer ${{ inputs.github_token }}'
+            _HEADER=(--header 'authorization: Bearer ${{ inputs.github_token }}')
           else
-            _HEADER=""
+            _HEADER=()
           fi
           if [ "${{ inputs.verible_version }}" = "latest" ]; then
-            VERIBLE_RELEASES_JSON=$(curl --header "$_HEADER" -fsSL https://api.github.com/repos/chipsalliance/verible/releases/latest)
+            VERIBLE_RELEASES_JSON=$(curl "${_HEADER[@]}" -fsSL https://api.github.com/repos/chipsalliance/verible/releases/latest)
             VERIBLE_TARBALL=$(echo $VERIBLE_RELEASES_JSON | jq -r '.assets[] | select(.browser_download_url | test("(?=.*linux-static)(?=.*x86_64)")).browser_download_url')
           else
             VERIBLE_TARBALL="https://github.com/chipsalliance/verible/releases/download/${{ inputs.verible_version }}/verible-${{ inputs.verible_version }}-linux-static-x86_64.tar.gz"


### PR DESCRIPTION
Following the discussion in #7, this implements the variable expansion of the optional header using [Bash's array syntax](https://www.gnu.org/software/bash/manual/html_node/Arrays.html).

To make the code more consistent, I also touched up the second if-clause, using Bash's `[[` conditional check - now [shellcheck](https://www.shellcheck.net/) won't complain. But if you prefer the POSIX compliant `[`, we can also drop my second commit.